### PR TITLE
Replace Travis CI with Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x, 1.15.x]
+        platform: [ubuntu-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Test
+      run: |
+        go get github.com/frankbraun/gocheck
+        export PATH=$GOPATH/bin:$PATH
+        make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: go
-go: 1.14
-before_install:
-  - go get github.com/frankbraun/gocheck
-  - go get -t github.com/mutecomm/go-sqlcipher/v4
-script:
-  - gocheck -g -c -e _example -e sqlite3_test

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 all:
 	env GO111MODULE=on go build -v ./...
 
+test:
+	gocheck -g -c -e _example -e sqlite3_test
+
 update-modules:
 	env GO111MODULE=on go get -u
 	env GO111MODULE=on go mod tidy -v


### PR DESCRIPTION
The motiviation behind this change is that Github Actions is obviously better integrated in Github than Travis CI and that it will be easy to run test against non Linux platforms, e.g. macOS or Windows.
Tests are now run for the three most recent Go versions, i.e. Go 1.13, 1.14 and 1.15 .
A new 'test' target was added to the Makefile.